### PR TITLE
Enhances README for Docker setup and adds wireguard patch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,7 @@ jobs:
 
       - id: meta
         uses: docker/metadata-action@v5
+        if: github.event_name != 'pull_request'
         with:
           images: |
             ghcr.io/${{ github.repository }}

--- a/README.md
+++ b/README.md
@@ -4,21 +4,45 @@ Private Internet Access manual connections scripts but in a docker container.
 
 ## Getting Started
 
-Simply run:
+The upstream scripts are fairly user-friendly and will prompt for input, so a minimal command does not strictly require configuration.
 
 ```shell
 docker run --rm -it unstoppablemango/pia-manual-connections:latest
 ```
 
+In practice you'll want to supply at least `PIA_USER` and `PIA_PASS`.
+
+```shell
+docker run --rm -it \
+  -e PIA_USER=p1234567 \
+  -e PIA_PASS=your-strong-password \
+  unstoppablemango/pia-manual-connections:latest
+```
+
+## Patches
+
+This repo contains a few small patches to the upstream.
+At the time of writing, these:
+
+- [Stop the scripts from printing PIA_TOKEN](./patches/001-echo-token.patch)
+- [Allow passing arguments to wireguard](./patches/002-wireguard-script-args.patch)
+
+### Why not contribute upstream?
+
+Mostly laziness, I'll get around to it eventually.
+
+There hasn't been a [release in a while](https://github.com/pia-foss/manual-connections/releases/tag/v2.0.0) and there are a [number](https://github.com/pia-foss/manual-connections/pull/192) [of](https://github.com/pia-foss/manual-connections/pull/185) [year+ old](https://github.com/pia-foss/manual-connections/pull/189) [open](https://github.com/pia-foss/manual-connections/pull/91) [PRs](https://github.com/pia-foss/manual-connections/pull/64) with recent activity that have yet to be merged.
+I'm not in much of a rush to contribute there.
+
 ## Docker
 
 The `unstoppablemango/pia-manual-connections` docker image defined in [Dockerfile](./Dockerfile) zips up github.com/pia-foss/manual-connections into a neat little container for easy consumption.
-The repository is located at `/src` with the entrypoint defined as [entrypoint.sh](./entrypoint.sh), which sources [/src/run_setup.sh](https://github.com/pia-foss/manual-connections/blob/master/run_setup.sh).
-A minimal set of configuration variables required to run the script can be found [here](https://github.com/pia-foss/manual-connections/#automated-setup).
+Within the container, the repository is located at `/src` with the entrypoint defined as [/src/entrypoint.sh](./entrypoint.sh). The entrypoint sources [/src/run_setup.sh](https://github.com/pia-foss/manual-connections/blob/master/run_setup.sh) from the upstream.
+A minimal set of configuration variables required to run the script can be found [in the source repository](https://github.com/pia-foss/manual-connections/#automated-setup).
 
 By default, the scripts will persist data such as the auth token and serverlist in `/opt/piavpn-manual`.
 You can mount a volume at this directory to interact with the script output.
 
 ### Configuration
 
-The supported environment variables are defined [over here](https://github.com/pia-foss/manual-connections/#automated-setup).
+For the most up-to-date configuration, refer to the [upstream repository](https://github.com/pia-foss/manual-connections/#automated-setup).

--- a/patches/002-wireguard-script-args.patch
+++ b/patches/002-wireguard-script-args.patch
@@ -1,0 +1,15 @@
+diff --git a/run_setup.sh b/run_setup.sh
+index f92f961..6a14db7 100755
+--- a/run_setup.sh
++++ b/run_setup.sh
+@@ -483,8 +483,8 @@ elif [[ $VPN_PROTOCOL == wireguard ]]; then
+   echo "WG_SERVER_IP=$dipAddress WG_HOSTNAME=$dipHostname" \\
+   echo -e "./connect_to_wireguard_with_token.sh${nc}"
+   echo
+-  PIA_PF=$PIA_PF PIA_TOKEN=$PIA_TOKEN DIP_TOKEN=$DIP_TOKEN \
+-    WG_SERVER_IP=$dipAddress WG_HOSTNAME=$dipHostname \
++  PIA_PF=$PIA_PF PIA_CONNECT=$PIA_CONNECT PIA_TOKEN=$PIA_TOKEN DIP_TOKEN=$DIP_TOKEN \
++    PIA_CONF_PATH=$PIA_CONF_PATH WG_SERVER_IP=$dipAddress WG_HOSTNAME=$dipHostname \
+     ./connect_to_wireguard_with_token.sh
+   rm -f /opt/piavpn-manual/latencyList
+   exit 0


### PR DESCRIPTION
Improves the README to provide comprehensive instructions for using the Docker image with necessary environment variables. Highlights the minimal setup required and the addition of user credentials for effective use.

Introduces patches to modify upstream scripts, including the ability to pass arguments to wireguard. Provides a rationale for not contributing patches upstream due to current activity and PR status.

Addresses detailed usage scenarios for increased clarity and user convenience.